### PR TITLE
Allows Jekyll 4.0

### DIFF
--- a/jekyll-ship.gemspec
+++ b/jekyll-ship.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "jekyll", "~> 3.8"
+  spec.add_dependency "jekyll", ">= 3.8", "< 5"
   spec.add_dependency 'activesupport', '~> 5.2'
   spec.add_dependency 'aws-sdk-s3', '~> 1.46'
 end

--- a/lib/jekyll/ship/commands/ship.rb
+++ b/lib/jekyll/ship/commands/ship.rb
@@ -1,14 +1,13 @@
 require 'active_support/core_ext/hash/keys'
+require 'jekyll/command'
 require 'jekyll/ship/services/github'
 require 'jekyll/ship/services/s3'
 require 'jekyll/ship/errors'
 
 module Jekyll
   module Commands
-    class Ship < Command
-
+    class Ship < Jekyll::Command
       class << self
-
         def init_with_program(prog)
           prog.command(:ship) do |c|
             c.syntax "ship <service> [options]"

--- a/lib/jekyll/ship/version.rb
+++ b/lib/jekyll/ship/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Ship
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/spec/jekyll/services/base_spec.rb
+++ b/spec/jekyll/services/base_spec.rb
@@ -1,16 +1,15 @@
-RSpec.describe "Jekyll::Ship::Services::Base" do
+require 'jekyll/ship/services/base'
 
+RSpec.describe Jekyll::Ship::Services::Base do
   describe '#build_command' do
     context 'with no options specified' do
-      it 'returns basic jekyll build command' do
-        expect(subject.build_command).to eq 'bundle exec jekyll build'
-      end
+      subject { described_class.new.send(:build_command) }
+      it { is_expected.to eq 'bundle exec jekyll build' }
     end
 
     context 'with a destination passed in' do
-      it 'returns jekyll build command with destination specified' do
-        expect(subject.build_command(destination: 'foo')).to eq 'bundle exec jekyll build -d foo'
-      end
+      subject { described_class.new.send(:build_command, destination: 'foo') }
+      it { is_expected.to eq 'bundle exec jekyll build -d foo' }
     end
   end
 end


### PR DESCRIPTION
* Relaxes Jekyll version requirements to allow for >= 3.8, < 5.
* Bumps version to 0.2.1.

Also,
* Fixes tests for Jekyll::Ship::Services::Base#build_command.
* Refactors how config is loaded for Jekyll::Ship::Services::Base.
* Removes unneeded methods form Jekyll::Ship::Services::Base.